### PR TITLE
fix: update project name and URLs in package.json and package-lock.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ There are many ways you can help:
 
 ## Reporting Issues
 
-If you find a bug or have an issue, please check the [open issues](https://github.com/subhamay-bhattacharyya-gha/terraform-template/issues) before creating a new one. If it’s not there, feel free to open a new issue and provide as much information as possible.
+If you find a bug or have an issue, please check the [open issues](https://github.com/subhamay-bhattacharyya-gha/gcp-terraform-bootstrap/issues) before creating a new one. If it’s not there, feel free to open a new issue and provide as much information as possible.
 
 ## Submitting Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "terraform-template",
+    "name": "gcp-terraform-bootstrap",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "terraform-template",
+            "name": "gcp-terraform-bootstrap",
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "terraform-template",
+    "name": "gcp-terraform-bootstrap",
     "version": "0.0.0",
     "description": "A custom Terraform module GitHub template repository to manage AWS resource with Semantic Release support.",
     "license": "MIT",
@@ -20,12 +20,12 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/subhamay-bhattacharyya/terraform-template.git"
+        "url": "git+https://github.com/subhamay-bhattacharyya/gcp-terraform-bootstrap.git"
     },
     "keywords": [],
     "author": "",
     "bugs": {
-        "url": "https://github.com/subhamay-bhattacharyya/terraform-template/issues"
+        "url": "https://github.com/subhamay-bhattacharyya/gcp-terraform-bootstrap/issues"
     },
-    "homepage": "https://github.com/subhamay-bhattacharyya/terraform-template#readme"
+    "homepage": "https://github.com/subhamay-bhattacharyya/gcp-terraform-bootstrap#readme"
 }


### PR DESCRIPTION
This pull request updates the project to reflect a repository rename from `terraform-template` to `gcp-terraform-bootstrap`. The changes ensure that all references within the codebase and documentation point to the new repository name and URL.

Repository and metadata updates:

* Updated the `name` field in `package.json` from `terraform-template` to `gcp-terraform-bootstrap`.
* Changed the repository URL, bugs URL, and homepage in `package.json` to use the new `gcp-terraform-bootstrap` repository.

Documentation update:

* Updated the issue reporting link in `CONTRIBUTING.md` to reference the new repository's issues page.