### PR TITLE
Add GCP project configuration for Cloud PubSub and update roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 ## [unreleased]
 
+### 🚀 Features
+
+- Add GCP project configuration for Cloud PubSub and update KMS roles
+
+### 🐛 Bug Fixes
+
+- Correct name for Cloud PubSub Topics and Subscriptions
+## [Rel-013-20260325162733] - 2026-03-25
+
 ### 🐛 Bug Fixes
 
 - Update service account source reference and output values
 - Update source reference for gcp_project_hierarchy module to specific version
+
+### 📚 Documentation
+
+- Update CHANGELOG.md [skip ci]
 ## [Rel-012-20260325154000] - 2026-03-25
 
 ### 🚀 Features

--- a/input-json/hierarchy.json
+++ b/input-json/hierarchy.json
@@ -9,6 +9,11 @@
       "parent_type": "folder",
       "parent_key": "000-gce-practice"
     },
+    "02-kms": {
+      "display_name": "fld-02-kms",
+      "parent_type": "folder",
+      "parent_key": "000-gce-practice"
+    },
     "03-cloud-run": {
       "display_name": "fld-03-cloud-run",
       "parent_type": "folder",
@@ -94,8 +99,8 @@
       "parent_type": "folder",
       "parent_key": "000-gce-practice"
     },
-    "02-kms": {
-      "display_name": "fld-02-kms",
+    "20-pubsub": {
+      "display_name": "fld-20-pubsub",
       "parent_type": "folder",
       "parent_key": "000-gce-practice"
     }
@@ -945,7 +950,8 @@
       "services": [
         "storage.googleapis.com",
         "iam.googleapis.com",
-        "cloudresourcemanager.googleapis.com"
+        "cloudresourcemanager.googleapis.com",
+        "cloudkms.googleapis.com"
       ],
       "labels": {
         "env": "devl",
@@ -960,6 +966,7 @@
         "display_name": "Terraform deployer for cloud storage project",
         "project_roles": [
           "roles/storage.admin",
+          "roles/cloudkms.admin",
           "roles/serviceusage.serviceUsageAdmin"
         ]
       }
@@ -1069,6 +1076,59 @@
           "roles/cloudtrace.admin",
           "roles/monitoring.admin",
           "roles/serviceusage.serviceUsageAdmin"
+        ]
+      }
+    },
+    "20-pubsub": {
+      "name": "Cloud PubSub Topics and Subscriptions",
+      "project_id": "prj-20-pubsub-16748",
+      "folder_key": "20-pubsub",
+      "billing_account": "010DEB-AF68D5-B8B7FE",
+      "notification_email": "subhamay.aws@gmail.com",
+      "alert_thresholds": {
+        "billing_amount": 150.0,
+        "threshold_rules": [
+          {
+            "threshold_percent": 0.25,
+            "spend_basis": "CURRENT_SPEND"
+          },
+          {
+            "threshold_percent": 0.5,
+            "spend_basis": "CURRENT_SPEND"
+          },
+          {
+            "threshold_percent": 1.0,
+            "spend_basis": "CURRENT_SPEND"
+          },
+          {
+            "threshold_percent": 1.1,
+            "spend_basis": "FORECASTED_SPEND"
+          }
+        ]
+      },
+      "services": [
+        "pubsub.googleapis.com",
+        "iam.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "monitoring.googleapis.com",
+        "cloudkms.googleapis.com"
+      ],
+      "labels": {
+        "env": "devl",
+        "team": "platform",
+        "managed-by": "terraform",
+        "gcp-service": "pubsub"
+      },
+      "enable_alerts": true,
+      "service_account": {
+        "enabled": true,
+        "account_id": "sa-20-pubsub",
+        "display_name": "Terraform deployer for pubsub project",
+        "project_roles": [
+          "roles/pubsub.admin",
+          "roles/iam.serviceAccountUser",
+          "roles/serviceusage.serviceUsageAdmin",
+          "roles/cloudkms.admin"
         ]
       }
     }

--- a/input-json/hierarchy.json
+++ b/input-json/hierarchy.json
@@ -1080,7 +1080,7 @@
       }
     },
     "20-pubsub": {
-      "name": "Cloud PubSub Topics and Subscriptions",
+      "name": "Cloud PubSub Topics and Subs",
       "project_id": "prj-20-pubsub-16748",
       "folder_key": "20-pubsub",
       "billing_account": "010DEB-AF68D5-B8B7FE",


### PR DESCRIPTION
This pull request adds configuration for a new GCP project focused on Cloud PubSub, updates KMS roles and services, and corrects naming for related resources. It also includes documentation updates in the changelog. The main changes are grouped below:

**GCP Project and Resource Configuration:**

* Added a new GCP project configuration for Cloud PubSub, including project details, billing, alert thresholds, enabled services (such as `pubsub.googleapis.com` and `cloudkms.googleapis.com`), labels, and a dedicated service account with appropriate roles.
* Corrected the folder and project key for the PubSub project from `02-kms` to `20-pubsub`, ensuring proper naming and hierarchy alignment.
* Added a new folder entry for `20-pubsub` in the project hierarchy.

**KMS Role and Service Updates:**

* Updated enabled services for the storage project to include `cloudkms.googleapis.com` and granted `roles/cloudkms.admin` to the Terraform deployer service account. [[1]](diffhunk://#diff-aba162ad8414ba676d4528caf415ab9f84e15d61a0660685cac5df67fa70dcb6L948-R954) [[2]](diffhunk://#diff-aba162ad8414ba676d4528caf415ab9f84e15d61a0660685cac5df67fa70dcb6R969)

**Documentation:**

* Updated `CHANGELOG.md` to reflect the new features, bug fixes, and documentation changes related to GCP project configuration and naming corrections.