### PR TITLE
Fix project_id values for serverless pipeline and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [unreleased]
 
+### 🐛 Bug Fixes
+
+- Correct project_id values for serverless pipeline and app engine
+## [Rel-015-20260407154846] - 2026-04-07
+
 ### 🚀 Features
 
 - Add serverless pipeline, bigquery, app engine, and cloud datastore configurations
@@ -7,6 +12,10 @@
 ### 🐛 Bug Fixes
 
 - Update name for serverless pipeline in hierarchy.json
+
+### 📚 Documentation
+
+- Update CHANGELOG.md [skip ci]
 ## [Rel-014-20260402161235] - 2026-04-02
 
 ### 🚀 Features

--- a/input-json/hierarchy.json
+++ b/input-json/hierarchy.json
@@ -1156,7 +1156,7 @@
     },
     "21-serverless-pipeline": {
       "name": "Serverless Pipeline",
-      "project_id": "prj-21-serverless-pipelin-16748",
+      "project_id": "prj-21-srvless-pipe-16748",
       "folder_key": "21-serverless-pipeline",
       "billing_account": "015898-2F7763-830474",
       "notification_email": "subhamay.aws@gmail.com",
@@ -1286,7 +1286,7 @@
     },
     "23-app-engine": {
       "name": "Google App Engine",
-      "project_id": "prj-23-app-engine-16748",
+      "project_id": "prj-23-appengine-16748",
       "folder_key": "23-app-engine",
       "billing_account": "015898-2F7763-830474",
       "notification_email": "subhamay.aws@gmail.com",


### PR DESCRIPTION
This pull request addresses incorrect `project_id` values for the serverless pipeline and app engine configurations, ensuring consistency across the codebase. It also updates the `CHANGELOG.md` to reflect these bug fixes and includes a documentation note.

Bug fixes to project configuration:

* Corrected the `project_id` for the serverless pipeline in `hierarchy.json` from `prj-21-serverless-pipelin-16748` to `prj-21-srvless-pipe-16748`
* Corrected the `project_id` for the app engine in `hierarchy.json` from `prj-23-app-engine-16748` to `prj-23-appengine-16748`

Documentation updates:

* Updated `CHANGELOG.md` to document the bug fixes and included a documentation section