### PR TITLE
Update App Engine name and project ID for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ### 🐛 Bug Fixes
 
+- Update app engine name and project_id for consistency
+## [Rel-016-20260407174039] - 2026-04-07
+
+### 🐛 Bug Fixes
+
 - Correct project_id values for serverless pipeline and app engine
+
+### 📚 Documentation
+
+- Update CHANGELOG.md [skip ci]
 ## [Rel-015-20260407154846] - 2026-04-07
 
 ### 🚀 Features

--- a/input-json/hierarchy.json
+++ b/input-json/hierarchy.json
@@ -1285,8 +1285,8 @@
       }
     },
     "23-app-engine": {
-      "name": "Google App Engine",
-      "project_id": "prj-23-appengine-16748",
+      "name": "GAE Standard and Flex",
+      "project_id": "prj-23-gae-16748",
       "folder_key": "23-app-engine",
       "billing_account": "015898-2F7763-830474",
       "notification_email": "subhamay.aws@gmail.com",


### PR DESCRIPTION
This pull request focuses on improving consistency in the naming and configuration of the App Engine environment. The key changes include updating the App Engine's name and project ID for clarity and consistency across the codebase, as well as updating the documentation to reflect these changes.

Configuration updates:

* Changed the `name` from "Google App Engine" to "GAE Standard and Flex" and updated the `project_id` to `prj-23-gae-16748` in `input-json/hierarchy.json` for consistency.

Documentation updates:

* Updated `CHANGELOG.md` to document the changes to the App Engine name and project_id, and included a new release entry.