### PR TITLE
Rename service from Firestore to File in hierarchy.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ### 🐛 Bug Fixes
 
+- Update service name from firestore to file in hierarchy.json
+## [Rel-017-20260407175941] - 2026-04-07
+
+### 🐛 Bug Fixes
+
 - Update app engine name and project_id for consistency
+
+### 📚 Documentation
+
+- Update CHANGELOG.md [skip ci]
 ## [Rel-016-20260407174039] - 2026-04-07
 
 ### 🐛 Bug Fixes

--- a/input-json/hierarchy.json
+++ b/input-json/hierarchy.json
@@ -820,7 +820,7 @@
         ]
       },
       "services": [
-        "firestore.googleapis.com",
+        "file.googleapis.com",
         "iam.googleapis.com",
         "cloudresourcemanager.googleapis.com"
       ],


### PR DESCRIPTION
This pull request fixes a service naming issue in the `hierarchy.json` configuration and updates the changelog to reflect the change. The main focus is to correct the service name from `firestore` to `file` for improved accuracy and consistency.

Bug Fixes:

* Updated the service name in `input-json/hierarchy.json` from `firestore.googleapis.com` to `file.googleapis.com` to ensure the correct service is referenced.

Documentation:

* Updated `CHANGELOG.md` to document the service name correction and included a note about the changelog update.